### PR TITLE
Fix crash when no data returned for NotLicensed response.

### DIFF
--- a/LicenseVerificationLibrary/LicenseValidator.cs
+++ b/LicenseVerificationLibrary/LicenseValidator.cs
@@ -142,15 +142,31 @@ namespace LicenseVerificationLibrary
         /// <param name="signature">
         /// server signature
         /// </param>
+        /// <seealso href="https://developer.android.com/google/play/licensing/licensing-reference.html#server-response-codes"/>
         public void Verify(IPublicKey publicKey, ServerResponseCode responseCode, string signedData, string signature)
         {
             string userId = null;
 
             // Skip signature check for unsuccessful requests
             ResponseData data = null;
-            if (responseCode == ServerResponseCode.Licensed || responseCode == ServerResponseCode.NotLicensed
+            if (responseCode == ServerResponseCode.Licensed 
+                || (responseCode == ServerResponseCode.NotLicensed && signedData != null && signature != null)
                 || responseCode == ServerResponseCode.LicensedOldKey)
             {
+                if (signedData == null)
+                {
+                    System.Diagnostics.Debug.WriteLine("Response doesn't carry signed data.");
+                    this.HandleInvalidResponse();
+                    return;
+                }
+
+                if (signature == null)
+                {
+                    System.Diagnostics.Debug.WriteLine("Response doesn't have a signature.");
+                    this.HandleInvalidResponse();
+                    return;
+                }
+
                 // Verify signature.
                 try
                 {

--- a/LicenseVerificationLibrary/Policy/IPolicy.cs
+++ b/LicenseVerificationLibrary/Policy/IPolicy.cs
@@ -25,8 +25,8 @@ namespace LicenseVerificationLibrary.Policy
         /// The result from validating the server response
         /// </param>
         /// <param name="rawData">
-        /// The raw server response data, can be null for 
-        /// <see cref="PolicyServerResponse.Retry"/>
+        /// The raw server response data, can be null except for 
+        /// <see cref="PolicyServerResponse.Licensed"/>
         /// </param>
         void ProcessServerResponse(PolicyServerResponse response, ResponseData rawData);
 


### PR DESCRIPTION
The library reports `NotLicensed` with null `signedData` and null `signature` happens e.g. when there is no user account associated with Google Play Store yet. This was causing a `NullPointerException`.

Also, this PR contains more robust handling of no data/no signature cases for Licensed response. Instead of a `NullPointerException`, the response is handled as invalid.