### PR TITLE
Proper handling of decoding extra data when no extra data present.

### DIFF
--- a/LicenseVerificationLibrary/Policy/PolicyExtensions.cs
+++ b/LicenseVerificationLibrary/Policy/PolicyExtensions.cs
@@ -49,12 +49,15 @@ namespace LicenseVerificationLibrary.Policy
         {
             var results = new Dictionary<string, string>();
 
-            IEnumerable<KeyValuePair<string, string>> parameters = GetParameters(extras);
-            foreach (KeyValuePair<string, string> item in parameters)
+            if (!string.IsNullOrEmpty(extras))
             {
-                int count = results.Keys.Count(x => x == item.Key);
-                string name = item.Key + (count != 0 ? count.ToString() : string.Empty);
-                results.Add(name, item.Value);
+                IEnumerable<KeyValuePair<string, string>> parameters = GetParameters(extras);
+                foreach (KeyValuePair<string, string> item in parameters)
+                {
+                    int count = results.Keys.Count(x => x == item.Key);
+                    string name = item.Key + (count != 0 ? count.ToString() : string.Empty);
+                    results.Add(name, item.Value);
+                }
             }
 
             return results;


### PR DESCRIPTION
The C# code for decoding extra data in the licensing server response, in the case there is no extra data, creates a dictionary with one spurious entry: an empty string as a key and an empty string as a value. The proper result would be dictionary with no entries (since there are no keys in empty extra data).

Empty extra data is sent by the licensing server when selecting LICENSED **test** option from the Developer Console.
