### PR TITLE
More distinct name of the background thread, to facilitate debugging

### DIFF
--- a/LicenseVerificationLibrary/LicenseChecker.cs
+++ b/LicenseVerificationLibrary/LicenseChecker.cs
@@ -152,7 +152,7 @@ namespace LicenseVerificationLibrary
             this.publicKey = GeneratePublicKey(encodedPublicKey);
             this.packageName = this.context.PackageName;
             this.versionCode = GetVersionCode(context, this.packageName);
-            var handlerThread = new HandlerThread("background thread");
+            var handlerThread = new HandlerThread("LVL background thread");
             handlerThread.Start();
             this.handler = new Handler(handlerThread.Looper);
         }


### PR DESCRIPTION
The background thread name used by LVL, "background thread" is not very informative. A project may have a number of background threads and it would be good to be able to tell them apart in the debugger.

I propose to rename the LVL thread to "LVL background thread".
