### PR TITLE
ServerManagedPolicy and ApkExpansionPolicy use the same preferences file

### DIFF
--- a/LicenseVerificationLibrary/Policy/ApkExpansionPolicy.cs
+++ b/LicenseVerificationLibrary/Policy/ApkExpansionPolicy.cs
@@ -34,7 +34,7 @@ namespace LicenseVerificationLibrary.Policy
 		/// <summary>
 		/// The file.
 		/// </summary>
-		public const string PreferencesFile = "com.android.vending.licensing.APKExpansionPolicy";
+		public new const string PreferencesFile = "com.android.vending.licensing.APKExpansionPolicy";
 
         /// <summary>
         /// The string that contains the key for finding file names.
@@ -97,7 +97,7 @@ namespace LicenseVerificationLibrary.Policy
         /// An obfuscator to be used when reading/writing to shared preferences.
         /// </param>
         public ApkExpansionPolicy(Context context, IObfuscator obfuscator)
-			: base(context, obfuscator)
+			: base(context, obfuscator, PreferencesFile)
         {
             this.expansionFiles = new[] { new ExpansionFile(), new ExpansionFile() };
         }

--- a/LicenseVerificationLibrary/Policy/ServerManagedPolicy.cs
+++ b/LicenseVerificationLibrary/Policy/ServerManagedPolicy.cs
@@ -88,9 +88,26 @@ namespace LicenseVerificationLibrary.Policy
         /// An obfuscator to be used with preferences.
         /// </param>
         public ServerManagedPolicy(Context context, IObfuscator obfuscator)
+            : this(context, obfuscator, PreferencesFile)
+        {}
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ServerManagedPolicy"/> class. 
+        /// The server managed policy.
+        /// </summary>
+        /// <param name="context">
+        /// The context for the current application
+        /// </param>
+        /// <param name="obfuscator">
+        /// An obfuscator to be used with preferences.
+        /// </param>
+        /// <param name="preferencesFile">
+        /// The name of the shared preferences file to use.
+        /// </param>
+        protected ServerManagedPolicy(Context context, IObfuscator obfuscator, string preferencesFile)
         {
             // Import old values
-            ISharedPreferences sp = context.GetSharedPreferences(PreferencesFile, FileCreationMode.Private);
+            ISharedPreferences sp = context.GetSharedPreferences(preferencesFile, FileCreationMode.Private);
 			this.Obfuscator = new PreferenceObfuscator(sp, obfuscator);
 
 			this.lastResponse = this.Obfuscator.GetValue<PolicyServerResponse>(Preferences.LastResponse, Preferences.DefaultLastResponse);


### PR DESCRIPTION
Originally, `ServerManagedPolicy` stored its data in a preferences file named "com.android.vending.licensing.ServerManagedPolicy", while `ApkExpansionPolicy` used a preferences file named "com.android.vending.licensing.APKExpansionPolicy". During refactoring (commit 1dbb36ff4c1e971a03e734dc18fbc066443b2f05), when `ApkExpansionPolicy` became a subclass of `ServerManagedPolicy`, things got lost. Now `ServerManagedPolicy` determines the file name, and while `ApkExpansionPolicy` still defines its own preferences file name, it is not used anywhere by the code — constants are not virtual.

This pull request fixes the problem and allows any subclass of `ServerManagedPolicy` to have its own preferences file. It also removes the compiler warning that the derived class constant masks the base class constant.