### PR TITLE
ObjectDisposedException when exiting an application

### DIFF
--- a/LicenseVerificationLibrary/LicenseChecker.cs
+++ b/LicenseVerificationLibrary/LicenseChecker.cs
@@ -152,7 +152,7 @@ namespace LicenseVerificationLibrary
             this.publicKey = GeneratePublicKey(encodedPublicKey);
             this.packageName = this.context.PackageName;
             this.versionCode = GetVersionCode(context, this.packageName);
-            var handlerThread = new HandlerThread("background thread");
+            var handlerThread = new HandlerThread("LVL background thread");
             handlerThread.Start();
             this.handler = new Handler(handlerThread.Looper);
         }

--- a/LicenseVerificationLibrary/LicenseChecker.cs
+++ b/LicenseVerificationLibrary/LicenseChecker.cs
@@ -80,6 +80,11 @@ namespace LicenseVerificationLibrary
         private readonly Handler handler;
 
         /// <summary>
+        /// The handler thread managing the looper, message queue and the handler.
+        /// </summary>
+        private readonly HandlerThread handlerThread;
+
+        /// <summary>
         /// The _locker.
         /// </summary>
         private readonly object locker;
@@ -152,7 +157,7 @@ namespace LicenseVerificationLibrary
             this.publicKey = GeneratePublicKey(encodedPublicKey);
             this.packageName = this.context.PackageName;
             this.versionCode = GetVersionCode(context, this.packageName);
-            var handlerThread = new HandlerThread("LVL background thread");
+            this.handlerThread = new HandlerThread("LVL background thread");
             handlerThread.Start();
             this.handler = new Handler(handlerThread.Looper);
         }
@@ -234,7 +239,7 @@ namespace LicenseVerificationLibrary
             lock (this.locker)
             {
                 this.CleanupService();
-                this.handler.Looper.Quit();
+                this.handlerThread.Quit();
             }
         }
 


### PR DESCRIPTION
`OnDestroy()` of the main activity calls `LicenseChecker.OnDestroy()` but that one throws an unhandled `ObjectDisposedException`. It happens when the code tries to access the `Looper` property on the `handler` field. The looper seems to be already gone. As a result, the application crashes.

Interestingly, although the bug is quite reproducible, it only happens on some handset types with a specific Android version, and only in release builds. I suspect it is a timing issue.

Short term solution: Quit the looper through the HandlerThread (PR attached).

Long term solution: replace the Android thread with .NET tasks.